### PR TITLE
URL detection in API response

### DIFF
--- a/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
+++ b/packages/bruno-app/src/components/CodeEditor/StyledWrapper.js
@@ -102,13 +102,18 @@ const StyledWrapper = styled.div`
   .cm-s-default span.cm-variable {
     color: #397d13 !important;
   }
-  
+
   //matching bracket fix
   .CodeMirror-matchingbracket {
     background: #5cc0b48c !important;
     text-decoration:unset;
   }
 
+  /* Ctrl + Hover URL highlight */
+  .cm-ctrl-hover-link {
+    text-decoration: underline !important;
+    cursor: pointer !important;
+  }
 `;
 
 export default StyledWrapper;

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -209,7 +209,8 @@ export default class CodeEditor extends React.Component {
   }
 
   setupUrlDetection(editor) {
-    const urlRegex = /https?:\/\/[^\s"',;]+/;
+    const urlRegex =
+      /(https?:\/\/[^\s"',;]+)|(www\.[^\s"',;]+)|(^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}([^\s"',;]*))/i;
 
     // Track CTRL key state
     const handleKeyDown = (event) => {

--- a/packages/bruno-app/src/components/CodeEditor/index.js
+++ b/packages/bruno-app/src/components/CodeEditor/index.js
@@ -243,7 +243,8 @@ export default class CodeEditor extends React.Component {
     const handleMouseDown = (event) => {
       if (this.isCtrlPressed && this.lastHoverLink) {
         event.preventDefault();
-        window.open(this.lastHoverLink, '_blank');
+        const win = window.open(this.lastHoverLink, '_blank', 'noopener,noreferrer');
+        if (win) win.opener = null;
         this.clearUrlHighlight();
       }
     };


### PR DESCRIPTION
# Description

This PR introduces URL detection functionality in API response viewer. When users hold the CTRL key and hover over URLs in JSON responses, the URLs are highlighted and become clickable.

## Features Added:
- **CTRL + Hover**: Hold CTRL and hover over any URL in API responses to highlight it with underline
- **CTRL + Click**: Click while holding CTRL to open the detected URL in a new browser tab
- **Visual Feedback**: URLs are highlighted with underline, cursor changes to pointer

## Technical Implementation:
- Uses CodeMirror's token detection to identify URLs in JSON responses
- Implements global CTRL key state tracking for reliable detection
- Adds proper event cleanup to prevent memory leaks

## Use Case:
This feature is particularly useful when working with APIs that return URLs (like image links, API endpoints, or resource URLs) in their responses. Instead of manually copying and pasting URLs, users can now directly click to open them.

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**

### Testing:
- Tested with JSON responses containing various URL formats
- Verified CTRL+hover and CTRL+click functionality

https://github.com/user-attachments/assets/15a7c0ed-c04f-4374-97f7-6eb53e770e93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Code Editor: CTRL-hover highlights detected URLs, shows a pointer cursor, and CTRL-click opens the link in a new tab.
  - URL detection runs in real time, tracks mouse/CTRL state, and cleans up highlights on navigation, CTRL release, mouse leave, or unmount.

- **Style**
  - Added hover styling for detected links (underline + pointer) to indicate interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->